### PR TITLE
Add hybrid cost function for scheduling with unit tests

### DIFF
--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .types import Edge, Node
 
 
-class Graph(nx.Graph):
+class Graph(nx.Graph): # type: ignore [type-arg]
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.executed_gates_next: list[dict[str, object]] = []

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 
@@ -10,8 +10,11 @@ if TYPE_CHECKING:
     from .processing_zone import ProcessingZone
     from .types import Edge, Node
 
-
-class Graph(nx.Graph):  # type: ignore [type-arg]
+class Graph(nx.Graph):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.executed_gates_next: list[dict[str, object]] = []
+    
     @property
     def mz_graph(self) -> Graph:
         return self._mz_graph

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .types import Edge, Node
 
 
-class Graph(nx.Graph): # type: ignore [type-arg]
+class Graph(nx.Graph):  # type: ignore [type-arg]
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.executed_gates_next: list[dict[str, object]] = []

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class Graph(nx.Graph):  # type: ignore [type-arg]
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.executed_gates_next: list[dict[str, object]] = []
+        self.executed_gates_next: list[dict[str, Any]] = []
 
     @property
     def mz_graph(self) -> Graph:

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
@@ -10,11 +10,12 @@ if TYPE_CHECKING:
     from .processing_zone import ProcessingZone
     from .types import Edge, Node
 
+
 class Graph(nx.Graph):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.executed_gates_next: list[dict[str, object]] = []
-    
+
     @property
     def mz_graph(self) -> Graph:
         return self._mz_graph

--- a/tests/test_outside_scheduling.py
+++ b/tests/test_outside_scheduling.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def test_cost_function_hybrid_first_example() -> None:
-    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g: Graph = Graph()
     g.add_node((0.0, 0.0), node_type="junction_node")
     g.add_node((0.0, 1.0), node_type="junction_node")
     g.add_node((1.0, 1.0), node_type="junction_node")
@@ -33,7 +33,7 @@ def test_cost_function_hybrid_first_example() -> None:
 
 
 def test_cost_function_hybrid_prefers_cycle_when_cheaper() -> None:
-    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g: Graph = Graph()
     g.add_node((0.0, 0.0), node_type="junction_node")
     g.add_node((0.0, 1.0), node_type="trap_node")
     g.add_node((1.0, 1.0), node_type="trap_node")
@@ -50,7 +50,7 @@ def test_cost_function_hybrid_prefers_cycle_when_cheaper() -> None:
 
 
 def test_cost_function_hybrid_prefers_path_when_cheaper() -> None:
-    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g: Graph = Graph()
     g.add_node((0.0, 0.0), node_type="junction_node")
     g.add_node((0.0, 1.0), node_type="trap_node")
     g.add_node((1.0, 1.0), node_type="trap_node")
@@ -67,7 +67,7 @@ def test_cost_function_hybrid_prefers_path_when_cheaper() -> None:
 
 
 def test_cost_function_hybrid_returns_0_on_tie() -> None:
-    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g: Graph = Graph()
     g.add_node((0.0, 0.0), node_type="junction_node")
     g.add_node((0.0, 1.0), node_type="trap_node")
 

--- a/tests/test_outside_scheduling.py
+++ b/tests/test_outside_scheduling.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mqt.ionshuttler.multi_shuttler.outside import scheduling
+from mqt.ionshuttler.multi_shuttler.outside.graph import Graph
+
+if TYPE_CHECKING:
+    from mqt.ionshuttler.multi_shuttler.outside.ion_types import Edge
+
+
+def test_cost_function_hybrid_first_example() -> None:
+    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g.add_node((0.0, 0.0), node_type="junction_node")
+    g.add_node((0.0, 1.0), node_type="junction_node")
+    g.add_node((1.0, 1.0), node_type="junction_node")
+    g.add_node((1.0, 0.0), node_type="junction_node")
+    g.add_node((1.0, 2.0), node_type="junction_node")
+
+    cycle: list[Edge] = [
+        ((0.0, 0.0), (0.0, 1.0)),
+        ((0.0, 1.0), (1.0, 1.0)),
+        ((1.0, 1.0), (1.0, 0.0)),
+        ((1.0, 0.0), (0.0, 0.0)),
+    ]
+    path: list[Edge] = [
+        ((0.0, 0.0), (0.0, 1.0)),
+        ((0.0, 1.0), (1.0, 1.0)),
+        ((1.0, 1.0), (1.0, 2.0)),
+    ]
+
+    assert scheduling.cost_function_hybrid(g, [1.0, 1.0], cycle, path) == 1
+
+
+def test_cost_function_hybrid_prefers_cycle_when_cheaper() -> None:
+    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g.add_node((0.0, 0.0), node_type="junction_node")
+    g.add_node((0.0, 1.0), node_type="trap_node")
+    g.add_node((1.0, 1.0), node_type="trap_node")
+    g.add_node((1.0, 2.0), node_type="trap_node")
+
+    cycle: list[Edge] = [((0.0, 0.0), (0.0, 1.0))]
+    path: list[Edge] = [((0.0, 1.0), (1.0, 1.0)), ((1.0, 1.0), (1.0, 2.0))]
+
+    # Choose weights so cycle is cheaper:
+    # cycle_cost = alpha*1 + beta*1
+    # path_cost  = alpha*2 + beta*0
+
+    assert scheduling.cost_function_hybrid(g, [1.0, 0.5], cycle, path) == 0
+
+
+def test_cost_function_hybrid_prefers_path_when_cheaper() -> None:
+    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g.add_node((0.0, 0.0), node_type="junction_node")
+    g.add_node((0.0, 1.0), node_type="trap_node")
+    g.add_node((1.0, 1.0), node_type="trap_node")
+    g.add_node((1.0, 2.0), node_type="trap_node")
+
+    cycle: list[Edge] = [((0.0, 0.0), (0.0, 1.0)), ((0.0, 1.0), (1.0, 1.0))]
+    path: list[Edge] = [((0.0, 1.0), (1.0, 1.0))]
+
+    # Make junctions expensive, so cycle loses:
+    # cycle_cost = 1*2 + 10*1 = 12
+    # path_cost  = 1*1 + 10*0 = 1
+
+    assert scheduling.cost_function_hybrid(g, [1.0, 10.0], cycle, path) == 1
+
+
+def test_cost_function_hybrid_returns_0_on_tie() -> None:
+    g: Graph = Graph()  # type: ignore[no-untyped-call]
+    g.add_node((0.0, 0.0), node_type="junction_node")
+    g.add_node((0.0, 1.0), node_type="trap_node")
+
+    cycle: list[Edge] = [((0.0, 0.0), (0.0, 1.0))]
+    path: list[Edge] = [((0.0, 0.0), (0.0, 1.0))]
+
+    assert scheduling.cost_function_hybrid(g, [1.0, 1.0], cycle, path) == 0

--- a/tests/test_outside_scheduling.py
+++ b/tests/test_outside_scheduling.py
@@ -54,7 +54,6 @@ def test_cost_function_hybrid_prefers_path_when_cheaper() -> None:
     g.add_node((0.0, 0.0), node_type="junction_node")
     g.add_node((0.0, 1.0), node_type="trap_node")
     g.add_node((1.0, 1.0), node_type="trap_node")
-    g.add_node((1.0, 2.0), node_type="trap_node")
 
     cycle: list[Edge] = [((0.0, 0.0), (0.0, 1.0)), ((0.0, 1.0), (1.0, 1.0))]
     path: list[Edge] = [((0.0, 1.0), (1.0, 1.0))]

--- a/tests/test_outside_scheduling.py
+++ b/tests/test_outside_scheduling.py
@@ -6,7 +6,7 @@ from mqt.ionshuttler.multi_shuttler.outside import scheduling
 from mqt.ionshuttler.multi_shuttler.outside.graph import Graph
 
 if TYPE_CHECKING:
-    from mqt.ionshuttler.multi_shuttler.outside.ion_types import Edge
+    from mqt.ionshuttler.multi_shuttler.outside.types import Edge
 
 
 def test_cost_function_hybrid_first_example() -> None:


### PR DESCRIPTION
## Description

This PR introduces a new `cost_function_hybrid` method to the outside scheduling module.
The function decides between a cycle-based or path-based routing strategy based on a
weighted cost model.

Comes with unit tests.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
