### PR TITLE
🐛 Fix sdist validation with uv 0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.2,<0.12.0"]
+requires = ["uv_build>=0.12.0,<0.13.0"]
 build-backend = "uv_build"
 
 [project]
@@ -204,6 +204,10 @@ convention = "google"
 
 
 [tool.check-sdist]
+# uv_build 0.12 emits a TOML 1.0-normalized pyproject.toml and preserves the
+# original file in source distributions, even when the source already is
+# TOML 1.0.
+sdist-only = ["pyproject.toml.orig"]
 git-only = [
     "docs/*",
     "tests/*",


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

The shared Python linter now runs with uv 0.12. IonShuttler's build-system
constraint still excluded that version, causing the source-distribution check to
warn about the mismatch and reject the backend-generated
`pyproject.toml.orig`.

This updates the supported `uv_build` range to 0.12 and declares the preserved
original metadata file as expected source-distribution-only content. The source
`pyproject.toml` already parses as TOML 1.0; the extra file is backend output,
not evidence that the project uses TOML 1.1-only syntax.

The failure was reproduced on the unchanged base with uv 0.12.0. The same exact
`check-sdist --inject-junk` command passes with this change, as does the full
lint session.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ionshuttler/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
