### PR TITLE
📄 Add license headers

### DIFF
--- a/.license-tools-config.json
+++ b/.license-tools-config.json
@@ -1,0 +1,43 @@
+{
+  "author": {
+    "name": "Chair for Design Automation, TUM",
+    "years": [2023, 2026]
+  },
+  "force_author": true,
+  "force_license": true,
+  "license": "MIT",
+  "title": false,
+  "include": ["**/*"],
+  "style_override_for_suffix": {
+    ".pyi": "DOCSTRING_STYLE",
+    ".in": "POUND_STYLE",
+    ".mlir": "SLASH_STYLE",
+    ".td": "SLASH_STYLE",
+    ".yaml": "POUND_STYLE",
+    ".toml": "POUND_STYLE",
+    ".yml": "POUND_STYLE",
+    ".nastyle": "SLASH_STYLE"
+  },
+  "exclude": [
+    "^\\.[^/]+",
+    "/\\.[^/]+",
+    ".*\\.qasm",
+    ".*\\.arch",
+    ".*\\.md",
+    ".*\\.bib",
+    ".*\\.cff",
+    ".*\\.css",
+    ".*\\.csv",
+    ".*\\.json",
+    ".*\\.html",
+    ".*\\.tfc",
+    ".*\\.qc",
+    ".*\\.real",
+    ".*\\.tex",
+    ".*\\.profile",
+    "uv\\.lock",
+    "py\\.typed",
+    ".*build.*",
+    "(^|/)LICENSE$"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,13 @@ repos:
       - id: typos
         priority: 3
 
+  ## Check license headers
+  - repo: https://github.com/emzeat/mz-lictools
+    rev: v2.9.0
+    hooks:
+      - id: license-tools
+        priority: 4
+
   ## Format BibTeX files with bibtex-tidy
   - repo: https://github.com/FlamingTempura/bibtex-tidy
     rev: v1.14.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Sphinx configuration file."""
 
 from __future__ import annotations

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env -S uv run --script --quiet
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
 
 # /// script
 # dependencies = ["nox"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 [build-system]
 requires = ["uv_build>=0.12.0,<0.13.0"]
 build-backend = "uv_build"
@@ -6,7 +13,8 @@ build-backend = "uv_build"
 name = "mqt-ionshuttler"
 version = "0.2.4"
 authors = [
-    { name = "Daniel Schoenberger", email = "daniel.schoenberger@tum.de"}
+    { name = "Daniel Schoenberger", email = "daniel.schoenberger@tum.de"},
+    { name = "Linus Schulte", email = "l.schule@tum.de"},
 ]
 description = "A solver for the shuttling problem in QCCD quantum computers"
 keywords = ["MQT", "quantum computing", "compilation", "shuttling", "design automation", "SAT solver"]
@@ -150,7 +158,6 @@ select = ["ALL"]
 ignore = [
   "C90",     # <...> too complex
   "COM812",  # Conflicts with formatter
-  "CPY001",  # Missing copyright notice
   "PLR09",   # Too many <...>
   "PLR1702", # Too many nested blocks
   "PLR2004", # Magic value used in comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ git-only = [
     "docs/*",
     "tests/*",
     ".gitignore",
+    ".license-tools-config.json",
     ".readthedocs.yaml",
     ".rumdl.toml",
     "AGENTS.md",

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Site customization shim to enable multiprocess coverage collection in tests.
 
 See: https://coverage.readthedocs.io/en/latest/subprocess.html.

--- a/src/mqt/ionshuttler/__init__.py
+++ b/src/mqt/ionshuttler/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/src/mqt/ionshuttler/linear/__init__.py
+++ b/src/mqt/ionshuttler/linear/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/actions.py
+++ b/src/mqt/ionshuttler/linear/actions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/architecture.py
+++ b/src/mqt/ionshuttler/linear/architecture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/compiler.py
+++ b/src/mqt/ionshuttler/linear/compiler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/config.py
+++ b/src/mqt/ionshuttler/linear/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/cost.py
+++ b/src/mqt/ionshuttler/linear/cost.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/expand.py
+++ b/src/mqt/ionshuttler/linear/expand.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/field_profile.py
+++ b/src/mqt/ionshuttler/linear/field_profile.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/parser.py
+++ b/src/mqt/ionshuttler/linear/parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/result.py
+++ b/src/mqt/ionshuttler/linear/result.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/search.py
+++ b/src/mqt/ionshuttler/linear/search.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/state.py
+++ b/src/mqt/ionshuttler/linear/state.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/linear/validation.py
+++ b/src/mqt/ionshuttler/linear/validation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/src/mqt/ionshuttler/multi_shuttler/__init__.py
+++ b/src/mqt/ionshuttler/multi_shuttler/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/src/mqt/ionshuttler/multi_shuttler/__main__.py
+++ b/src/mqt/ionshuttler/multi_shuttler/__main__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 import argparse
 import json
 import pathlib

--- a/src/mqt/ionshuttler/multi_shuttler/circuit_parsing.py
+++ b/src/mqt/ionshuttler/multi_shuttler/circuit_parsing.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import re

--- a/src/mqt/ionshuttler/multi_shuttler/circuit_types.py
+++ b/src/mqt/ionshuttler/multi_shuttler/circuit_types.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mqt/ionshuttler/multi_shuttler/gate_partitioning_tabu.py
+++ b/src/mqt/ionshuttler/multi_shuttler/gate_partitioning_tabu.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import itertools

--- a/src/mqt/ionshuttler/multi_shuttler/inside/__init__.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/src/mqt/ionshuttler/multi_shuttler/inside/compilation.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/compilation.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/mqt/ionshuttler/multi_shuttler/inside/cycles.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/cycles.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import random

--- a/src/mqt/ionshuttler/multi_shuttler/inside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/graph.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/src/mqt/ionshuttler/multi_shuttler/inside/graph_creator.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/graph_creator.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import random

--- a/src/mqt/ionshuttler/multi_shuttler/inside/graph_utils.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/graph_utils.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mqt/ionshuttler/multi_shuttler/inside/ion_types.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/ion_types.py
@@ -1,2 +1,9 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 Node = tuple[int, int]
 Edge = tuple[Node, Node]

--- a/src/mqt/ionshuttler/multi_shuttler/inside/partition.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/partition.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/mqt/ionshuttler/multi_shuttler/inside/paths.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/paths.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mqt/ionshuttler/multi_shuttler/inside/plotting.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/plotting.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/mqt/ionshuttler/multi_shuttler/inside/processing_zone.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/processing_zone.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mqt/ionshuttler/multi_shuttler/inside/scheduling.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/scheduling.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import contextlib

--- a/src/mqt/ionshuttler/multi_shuttler/inside/shuttle.py
+++ b/src/mqt/ionshuttler/multi_shuttler/inside/shuttle.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pathlib

--- a/src/mqt/ionshuttler/multi_shuttler/main.py
+++ b/src/mqt/ionshuttler/multi_shuttler/main.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import math

--- a/src/mqt/ionshuttler/multi_shuttler/outside/__init__.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/src/mqt/ionshuttler/multi_shuttler/outside/compilation.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/compilation.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import math

--- a/src/mqt/ionshuttler/multi_shuttler/outside/cycles.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/cycles.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import random

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph_creator.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph_creator.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import math

--- a/src/mqt/ionshuttler/multi_shuttler/outside/graph_utils.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/graph_utils.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mqt/ionshuttler/multi_shuttler/outside/ion_types.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/ion_types.py
@@ -1,2 +1,9 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 Node = tuple[float, float]
 Edge = tuple[Node, Node]

--- a/src/mqt/ionshuttler/multi_shuttler/outside/partition.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/partition.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/mqt/ionshuttler/multi_shuttler/outside/paths.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/paths.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 # from compilation import is_qasm_file, manual_copy_dag, parse_qasm, remove_node, update_sequence
 from __future__ import annotations
 

--- a/src/mqt/ionshuttler/multi_shuttler/outside/plotting.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/plotting.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import math

--- a/src/mqt/ionshuttler/multi_shuttler/outside/processing_zone.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/processing_zone.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mqt/ionshuttler/multi_shuttler/outside/scheduling.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/scheduling.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import contextlib

--- a/src/mqt/ionshuttler/multi_shuttler/outside/shuttle.py
+++ b/src/mqt/ionshuttler/multi_shuttler/outside/shuttle.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import contextlib

--- a/src/mqt/ionshuttler/single_shuttler/__init__.py
+++ b/src/mqt/ionshuttler/single_shuttler/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/src/mqt/ionshuttler/single_shuttler/__main__.py
+++ b/src/mqt/ionshuttler/single_shuttler/__main__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 import argparse
 import json
 import pathlib

--- a/src/mqt/ionshuttler/single_shuttler/compilation.py
+++ b/src/mqt/ionshuttler/single_shuttler/compilation.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import math

--- a/src/mqt/ionshuttler/single_shuttler/cycles.py
+++ b/src/mqt/ionshuttler/single_shuttler/cycles.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mqt/ionshuttler/single_shuttler/graph_utils.py
+++ b/src/mqt/ionshuttler/single_shuttler/graph_utils.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mqt/ionshuttler/single_shuttler/main.py
+++ b/src/mqt/ionshuttler/single_shuttler/main.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 import random
 import sys
 import time

--- a/src/mqt/ionshuttler/single_shuttler/memory_sat.py
+++ b/src/mqt/ionshuttler/single_shuttler/memory_sat.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import contextlib

--- a/src/mqt/ionshuttler/single_shuttler/plotting.py
+++ b/src/mqt/ionshuttler/single_shuttler/plotting.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from collections import defaultdict

--- a/src/mqt/ionshuttler/single_shuttler/run_benchmarks.py
+++ b/src/mqt/ionshuttler/single_shuttler/run_benchmarks.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 import math
 import time
 from pathlib import Path

--- a/src/mqt/ionshuttler/single_shuttler/run_heuristic.py
+++ b/src/mqt/ionshuttler/single_shuttler/run_heuristic.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 import argparse
 import json
 import pathlib

--- a/src/mqt/ionshuttler/single_shuttler/scheduling.py
+++ b/src/mqt/ionshuttler/single_shuttler/scheduling.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import contextlib

--- a/src/mqt/ionshuttler/single_shuttler/types.py
+++ b/src/mqt/ionshuttler/single_shuttler/types.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 import networkx as nx
 
 Node = tuple[int, int]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Shared fixtures for mqt-ionshuttler tests."""
 
 from __future__ import annotations

--- a/tests/linear/__init__.py
+++ b/tests/linear/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/conftest.py
+++ b/tests/linear/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_actions.py
+++ b/tests/linear/test_actions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_architecture.py
+++ b/tests/linear/test_architecture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_compiler.py
+++ b/tests/linear/test_compiler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_config.py
+++ b/tests/linear/test_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_contract.py
+++ b/tests/linear/test_contract.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_cost.py
+++ b/tests/linear/test_cost.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_expand.py
+++ b/tests/linear/test_expand.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_imports.py
+++ b/tests/linear/test_imports.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_parser.py
+++ b/tests/linear/test_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_result.py
+++ b/tests/linear/test_result.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_search.py
+++ b/tests/linear/test_search.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_state.py
+++ b/tests/linear/test_state.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/linear/test_validation.py
+++ b/tests/linear/test_validation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Tests for the CLI entry points (console_scripts).
 
 Subprocess tests are used for --help / missing-arg smoke tests.

--- a/tests/test_gate_partitioning_tabu.py
+++ b/tests/test_gate_partitioning_tabu.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Tests for the fine-grained tabu gate partitioner."""
 
 from __future__ import annotations

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Basic import and smoke tests for mqt-ionshuttler."""
 
 from __future__ import annotations

--- a/tests/test_main_mode_config.py
+++ b/tests/test_main_mode_config.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Tests for conflict-resolution mode config validation."""
 
 from __future__ import annotations

--- a/tests/test_multi_shuttler_inside.py
+++ b/tests/test_multi_shuttler_inside.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Tests for the multi_shuttler (heuristic solver) subpackage."""
 
 from __future__ import annotations

--- a/tests/test_multi_shuttler_outside.py
+++ b/tests/test_multi_shuttler_outside.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Tests for the multi_shuttler (heuristic solver) subpackage."""
 
 from __future__ import annotations

--- a/tests/test_outside_scheduling.py
+++ b/tests/test_outside_scheduling.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/tests/test_single_shuttler.py
+++ b/tests/test_single_shuttler.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Tests for the single_shuttler (exact solver) subpackage."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This adds MIT license headers to all source files and enforces them going forward via the `mz-lictools` pre-commit hook, configured in `.license-tools-config.json`. Existing headers are unified to the `2023 - 2026` copyright range. Since the hook now covers this, `ruff`'s `CPY001` is no longer ignored.

## AI notice

This PR was created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ionshuttler/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
